### PR TITLE
Force HTTPS for Secure Context

### DIFF
--- a/website/coi-serviceworker.min.js
+++ b/website/coi-serviceworker.min.js
@@ -89,7 +89,10 @@ if (typeof window === 'undefined') {
         if (window.crossOriginIsolated !== false || !coi.shouldRegister()) return;
 
         if (!window.isSecureContext) {
-            !coi.quiet && console.log("COOP/COEP Service Worker not registered, a secure context is required.");
+            !coi.quiet && console.log("COOP/COEP Service Worker not registered, a secure context is required, will try to load through HTTPS if currently loading through HTTP.");
+            if (window.location.protocol === 'http:') {
+                window.location.href = window.location.href.replace('http:', 'https:')
+            }
             return;
         }
 


### PR DESCRIPTION
Use JavaScript to force HTTPS when trying to load over HTTP, enables Secure Context so SharedArrayBuffer can be used 